### PR TITLE
Set up pyransame as a dataset accessor in PyVista

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -33,7 +33,10 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         python -m pip install -r requirements-test.txt
-    - name: Install pyvista version
+    - name: Install pyvista (latest)
+      if: ${{ matrix.pyvista-version == 'latest' }}
+      run: python -m pip install --upgrade pyvista
+    - name: Install pyvista (pinned)
       if: ${{ matrix.pyvista-version != 'latest' }}
       run: python -m pip install pyvista==${{ matrix.pyvista-version }}
     - name: Install vtk version
@@ -48,8 +51,6 @@ jobs:
         pytest tests --cov=src/pyransame --durations=10
     - name: Upload coverage reports to Codecov
       uses: codecov/codecov-action@v5
-      with:
-        flags: py${{ matrix.python-version }}-pv${{ matrix.pyvista-version }}-vtk${{ matrix.vtk-version }}
       env:
         CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
   type-check:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -48,6 +48,8 @@ jobs:
         pytest tests --cov=src/pyransame --durations=10
     - name: Upload coverage reports to Codecov
       uses: codecov/codecov-action@v5
+      with:
+        flags: py${{ matrix.python-version }}-pv${{ matrix.pyvista-version }}-vtk${{ matrix.vtk-version }}
       env:
         CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
   type-check:

--- a/README.md
+++ b/README.md
@@ -13,35 +13,35 @@ All linear[^1] cells from [vtk](https://gitlab.kitware.com/vtk/vtk) are supporte
 
 ## PyVista dataset accessor
 
-On PyVista 0.48+, `pip install pyransame` registers a `ransam`
+On PyVista 0.48+, `pip install pyransame` registers a `ransame`
 accessor on every PyVista dataset. No extra import or registration step
 is required. PyVista discovers the accessor through the
 `pyvista.accessors` entry point and loads it lazily the first time
-`mesh.ransam` is used.
+`mesh.ransame` is used.
 
 ```python
 import pyvista as pv
 from pyvista import examples
 
 bunny = examples.download_bunny()
-points = bunny.ransam.surface_points(500)        # numpy array, shape (500, 3)
-sampled = bunny.ransam.surface_dataset(500)      # pyvista.PolyData with interpolated arrays
+points = bunny.ransame.surface_points(500)        # numpy array, shape (500, 3)
+sampled = bunny.ransame.surface_dataset(500)      # pyvista.PolyData with interpolated arrays
 ```
 
 The accessor mirrors the top-level functions:
 
 | Method                          | Equivalent function                  |
 | ------------------------------- | ------------------------------------ |
-| `mesh.ransam.surface_points(n)` | `pyransame.random_surface_points`    |
-| `mesh.ransam.surface_dataset(n)`| `pyransame.random_surface_dataset`   |
-| `mesh.ransam.volume_points(n)`  | `pyransame.random_volume_points`     |
-| `mesh.ransam.volume_dataset(n)` | `pyransame.random_volume_dataset`    |
-| `mesh.ransam.line_points(n)`    | `pyransame.random_line_points`       |
-| `mesh.ransam.line_dataset(n)`   | `pyransame.random_line_dataset`      |
-| `mesh.ransam.vertex_points(n)`  | `pyransame.random_vertex_points`     |
-| `mesh.ransam.vertex_dataset(n)` | `pyransame.random_vertex_dataset`    |
-| `mesh.ransam.points(n)`         | dispatch by cell dimension           |
-| `mesh.ransam.dataset(n)`        | dispatch by cell dimension           |
+| `mesh.ransame.surface_points(n)` | `pyransame.random_surface_points`    |
+| `mesh.ransame.surface_dataset(n)`| `pyransame.random_surface_dataset`   |
+| `mesh.ransame.volume_points(n)`  | `pyransame.random_volume_points`     |
+| `mesh.ransame.volume_dataset(n)` | `pyransame.random_volume_dataset`    |
+| `mesh.ransame.line_points(n)`    | `pyransame.random_line_points`       |
+| `mesh.ransame.line_dataset(n)`   | `pyransame.random_line_dataset`      |
+| `mesh.ransame.vertex_points(n)`  | `pyransame.random_vertex_points`     |
+| `mesh.ransame.vertex_dataset(n)` | `pyransame.random_vertex_dataset`    |
+| `mesh.ransame.points(n)`         | dispatch by cell dimension           |
+| `mesh.ransame.dataset(n)`        | dispatch by cell dimension           |
 
 `points` and `dataset` infer the sampler from the cell dimensions on
 the mesh: vertex (0D), line (1D), surface (2D), or volume (3D). Mixed
@@ -49,11 +49,11 @@ dimensions raise `ValueError`. Pass `kind="vertex" | "line" | "surface"
 | "volume"` to override:
 
 ```python
-sampled = mixed_mesh.ransam.dataset(500, kind="surface")
+sampled = mixed_mesh.ransame.dataset(500, kind="surface")
 ```
 
 On older PyVista releases the package still installs and imports
-cleanly; only the `mesh.ransam` namespace is unavailable. Use the
+cleanly; only the `mesh.ransame` namespace is unavailable. Use the
 top-level `pyransame.random_*` functions in that case.
 
 ## Random sampling on a 2D surface

--- a/README.md
+++ b/README.md
@@ -11,6 +11,40 @@ All linear[^1] cells from [vtk](https://gitlab.kitware.com/vtk/vtk) are supporte
 
 [^1]: Linear here means not inheriting from `vtkNonLinearCell`.
 
+## PyVista dataset accessor
+
+On PyVista 0.48+, `pip install pyransame` registers a `ransam`
+accessor on every PyVista dataset. No extra import or registration step
+is required. PyVista discovers the accessor through the
+`pyvista.accessors` entry point and loads it lazily the first time
+`mesh.ransam` is used.
+
+```python
+import pyvista as pv
+from pyvista import examples
+
+bunny = examples.download_bunny()
+points = bunny.ransam.surface_points(500)        # numpy array, shape (500, 3)
+sampled = bunny.ransam.surface_dataset(500)      # pyvista.PolyData with interpolated arrays
+```
+
+The accessor mirrors the top-level functions:
+
+| Method                          | Equivalent function                  |
+| ------------------------------- | ------------------------------------ |
+| `mesh.ransam.surface_points(n)` | `pyransame.random_surface_points`    |
+| `mesh.ransam.surface_dataset(n)`| `pyransame.random_surface_dataset`   |
+| `mesh.ransam.volume_points(n)`  | `pyransame.random_volume_points`     |
+| `mesh.ransam.volume_dataset(n)` | `pyransame.random_volume_dataset`    |
+| `mesh.ransam.line_points(n)`    | `pyransame.random_line_points`       |
+| `mesh.ransam.line_dataset(n)`   | `pyransame.random_line_dataset`      |
+| `mesh.ransam.vertex_points(n)`  | `pyransame.random_vertex_points`     |
+| `mesh.ransam.vertex_dataset(n)` | `pyransame.random_vertex_dataset`    |
+
+On older PyVista releases the package still installs and imports
+cleanly; only the `mesh.ransam` namespace is unavailable. Use the
+top-level `pyransame.random_*` functions in that case.
+
 ## Random sampling on a 2D surface
 
 ![Samples on a bunny](/doc/_static/surface_sampling.png)

--- a/README.md
+++ b/README.md
@@ -40,6 +40,17 @@ The accessor mirrors the top-level functions:
 | `mesh.ransam.line_dataset(n)`   | `pyransame.random_line_dataset`      |
 | `mesh.ransam.vertex_points(n)`  | `pyransame.random_vertex_points`     |
 | `mesh.ransam.vertex_dataset(n)` | `pyransame.random_vertex_dataset`    |
+| `mesh.ransam.points(n)`         | dispatch by cell dimension           |
+| `mesh.ransam.dataset(n)`        | dispatch by cell dimension           |
+
+`points` and `dataset` infer the sampler from the cell dimensions on
+the mesh: vertex (0D), line (1D), surface (2D), or volume (3D). Mixed
+dimensions raise `ValueError`. Pass `kind="vertex" | "line" | "surface"
+| "volume"` to override:
+
+```python
+sampled = mixed_mesh.ransam.dataset(500, kind="surface")
+```
 
 On older PyVista releases the package still installs and imports
 cleanly; only the `mesh.ransam` namespace is unavailable. Use the

--- a/doc/api.rst
+++ b/doc/api.rst
@@ -14,3 +14,12 @@ API Documentation
    random_line_dataset
    random_vertex_points
    random_vertex_dataset
+
+PyVista dataset accessor
+------------------------
+
+Registered automatically on PyVista >= 0.48 via the
+``pyvista.accessors`` entry point.
+
+.. autoclass:: pyransame.accessor.RansameAccessor
+   :members:

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -54,6 +54,18 @@ numpydoc_validation_checks = {
     "SA01",  # do not require see also
 }
 
+# Skip validation of the accessor wrapper methods — they are thin
+# forwarders whose parameters and return values are documented on the
+# top-level ``random_*`` functions they call.
+numpydoc_validation_exclude = {
+    r"pyransame\.accessor\.RansameAccessor.*",
+}
+
+# Don't emit a separate toctree entry for each class member — autoclass
+# already documents methods inline, so the implicit ``_stubs`` lookups
+# numpydoc would generate point at non-existent stub files.
+numpydoc_class_members_toctree = False
+
 import re
 
 # from pyvista

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -60,7 +60,15 @@ Accessor method                   Equivalent function
 ``mesh.ransam.line_dataset``      :func:`pyransame.random_line_dataset`
 ``mesh.ransam.vertex_points``     :func:`pyransame.random_vertex_points`
 ``mesh.ransam.vertex_dataset``    :func:`pyransame.random_vertex_dataset`
+``mesh.ransam.points``            dispatch by cell dimension
+``mesh.ransam.dataset``           dispatch by cell dimension
 ================================  ==================================
+
+``points`` and ``dataset`` introspect ``mesh.distinct_cell_types`` to
+choose the sampler (vertex, line, surface, or volume). Meshes that
+carry cells of more than one dimension raise :class:`ValueError`; pass
+``kind="vertex" | "line" | "surface" | "volume"`` to force a specific
+sampler.
 
 On older PyVista releases the package still installs and imports
 cleanly; only the ``mesh.ransam`` namespace is unavailable, and the

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -18,7 +18,7 @@ PYthon RAndom SAmpling for MEshes (pyransame) chooses random samples of points w
 
    Sample points on mesh using ``pyransame``.
 
-   >>> points = pyransame.random_surface_dataset(antarctica, 500)
+   >>> points = antarctica.ransam.surface_dataset(500)
 
    Plot points on mesh.
 

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -30,6 +30,42 @@ PYthon RAndom SAmpling for MEshes (pyransame) chooses random samples of points w
    >>> pl.show()
 
 
+PyVista dataset accessor
+========================
+
+On PyVista 0.48 and newer, ``pip install pyransame`` registers a
+``ransam`` accessor on every PyVista dataset. PyVista discovers it
+through the ``pyvista.accessors`` entry point and imports the plugin
+lazily the first time ``mesh.ransam`` is used.
+
+.. code-block:: python
+
+    import pyvista as pv
+    from pyvista import examples
+
+    bunny = examples.download_bunny()
+    points = bunny.ransam.surface_points(500)
+    sampled = bunny.ransam.surface_dataset(500)
+
+The accessor exposes a method for each top-level sampling function:
+
+================================  ==================================
+Accessor method                   Equivalent function
+================================  ==================================
+``mesh.ransam.surface_points``    :func:`pyransame.random_surface_points`
+``mesh.ransam.surface_dataset``   :func:`pyransame.random_surface_dataset`
+``mesh.ransam.volume_points``     :func:`pyransame.random_volume_points`
+``mesh.ransam.volume_dataset``    :func:`pyransame.random_volume_dataset`
+``mesh.ransam.line_points``       :func:`pyransame.random_line_points`
+``mesh.ransam.line_dataset``      :func:`pyransame.random_line_dataset`
+``mesh.ransam.vertex_points``     :func:`pyransame.random_vertex_points`
+``mesh.ransam.vertex_dataset``    :func:`pyransame.random_vertex_dataset`
+================================  ==================================
+
+On older PyVista releases the package still installs and imports
+cleanly; only the ``mesh.ransam`` namespace is unavailable, and the
+top-level ``pyransame.random_*`` functions should be used instead.
+
 For more usage see :ref:`examples`.
 
 Indices and tables

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -18,7 +18,7 @@ PYthon RAndom SAmpling for MEshes (pyransame) chooses random samples of points w
 
    Sample points on mesh using ``pyransame``.
 
-   >>> points = antarctica.ransam.surface_dataset(500)
+   >>> points = antarctica.ransame.surface_dataset(500)
 
    Plot points on mesh.
 
@@ -34,9 +34,9 @@ PyVista dataset accessor
 ========================
 
 On PyVista 0.48 and newer, ``pip install pyransame`` registers a
-``ransam`` accessor on every PyVista dataset. PyVista discovers it
+``ransame`` accessor on every PyVista dataset. PyVista discovers it
 through the ``pyvista.accessors`` entry point and imports the plugin
-lazily the first time ``mesh.ransam`` is used.
+lazily the first time ``mesh.ransame`` is used.
 
 .. code-block:: python
 
@@ -44,24 +44,24 @@ lazily the first time ``mesh.ransam`` is used.
     from pyvista import examples
 
     bunny = examples.download_bunny()
-    points = bunny.ransam.surface_points(500)
-    sampled = bunny.ransam.surface_dataset(500)
+    points = bunny.ransame.surface_points(500)
+    sampled = bunny.ransame.surface_dataset(500)
 
 The accessor exposes a method for each top-level sampling function:
 
 ================================  ==================================
 Accessor method                   Equivalent function
 ================================  ==================================
-``mesh.ransam.surface_points``    :func:`pyransame.random_surface_points`
-``mesh.ransam.surface_dataset``   :func:`pyransame.random_surface_dataset`
-``mesh.ransam.volume_points``     :func:`pyransame.random_volume_points`
-``mesh.ransam.volume_dataset``    :func:`pyransame.random_volume_dataset`
-``mesh.ransam.line_points``       :func:`pyransame.random_line_points`
-``mesh.ransam.line_dataset``      :func:`pyransame.random_line_dataset`
-``mesh.ransam.vertex_points``     :func:`pyransame.random_vertex_points`
-``mesh.ransam.vertex_dataset``    :func:`pyransame.random_vertex_dataset`
-``mesh.ransam.points``            dispatch by cell dimension
-``mesh.ransam.dataset``           dispatch by cell dimension
+``mesh.ransame.surface_points``    :func:`pyransame.random_surface_points`
+``mesh.ransame.surface_dataset``   :func:`pyransame.random_surface_dataset`
+``mesh.ransame.volume_points``     :func:`pyransame.random_volume_points`
+``mesh.ransame.volume_dataset``    :func:`pyransame.random_volume_dataset`
+``mesh.ransame.line_points``       :func:`pyransame.random_line_points`
+``mesh.ransame.line_dataset``      :func:`pyransame.random_line_dataset`
+``mesh.ransame.vertex_points``     :func:`pyransame.random_vertex_points`
+``mesh.ransame.vertex_dataset``    :func:`pyransame.random_vertex_dataset`
+``mesh.ransame.points``            dispatch by cell dimension
+``mesh.ransame.dataset``           dispatch by cell dimension
 ================================  ==================================
 
 ``points`` and ``dataset`` introspect ``mesh.distinct_cell_types`` to
@@ -71,7 +71,7 @@ carry cells of more than one dimension raise :class:`ValueError`; pass
 sampler.
 
 On older PyVista releases the package still installs and imports
-cleanly; only the ``mesh.ransam`` namespace is unavailable, and the
+cleanly; only the ``mesh.ransame`` namespace is unavailable, and the
 top-level ``pyransame.random_*`` functions should be used instead.
 
 For more usage see :ref:`examples`.

--- a/examples_src/plot_01_random_surface_sampling.py
+++ b/examples_src/plot_01_random_surface_sampling.py
@@ -25,11 +25,11 @@ antarctica.points /= 1000.0  # convert to kilometers
 ###############################################################################
 # sample 500 points uniformly randomly.
 
-points = antarctica.ransam.surface_dataset(500)
+points = antarctica.ransame.surface_dataset(500)
 points
 
 ###############################################################################
-# The ``ransam`` accessor on the dataset (registered by ``pyransame``)
+# The ``ransame`` accessor on the dataset (registered by ``pyransame``)
 # forwards to :func:`pyransame.random_surface_dataset`, which returns a
 # `pyvista.PolyData` object
 # containing 500 points (and 500 corresponding vertex cells).  The cell and

--- a/examples_src/plot_01_random_surface_sampling.py
+++ b/examples_src/plot_01_random_surface_sampling.py
@@ -25,11 +25,13 @@ antarctica.points /= 1000.0  # convert to kilometers
 ###############################################################################
 # sample 500 points uniformly randomly.
 
-points = pyransame.random_surface_dataset(antarctica, 500)
+points = antarctica.ransam.surface_dataset(500)
 points
 
 ###############################################################################
-# :func:`pyransame.random_surface_dataset` returns a `pyvista.PolyData` object
+# The ``ransam`` accessor on the dataset (registered by ``pyransame``)
+# forwards to :func:`pyransame.random_surface_dataset`, which returns a
+# `pyvista.PolyData` object
 # containing 500 points (and 500 corresponding vertex cells).  The cell and
 # point data is also sampled onto ``points``. Each randomly sampled point is
 # plotted as a sphere with radius 50 km and colored by ``ssavelocity``.

--- a/examples_src/plot_02_weighted_sampling.py
+++ b/examples_src/plot_02_weighted_sampling.py
@@ -33,7 +33,7 @@ weights = (ymax - antarctica.cell_centers().points[:, 1]) ** 2
 ###############################################################################
 # Do weighted sampling.
 
-points = pyransame.random_surface_dataset(antarctica, 500, weights=weights)
+points = antarctica.ransam.surface_dataset(500, weights=weights)
 
 ###############################################################################
 # Now plot result.
@@ -49,7 +49,7 @@ pl.show()
 # The same thing can be done with cell data on the mesh.
 
 antarctica.cell_data["weights"] = weights
-points = pyransame.random_surface_dataset(antarctica, 500, weights="weights")
+points = antarctica.ransam.surface_dataset(500, weights="weights")
 
 ###############################################################################
 # Now plot result. The result will be slightly different due to random nature

--- a/examples_src/plot_02_weighted_sampling.py
+++ b/examples_src/plot_02_weighted_sampling.py
@@ -33,7 +33,7 @@ weights = (ymax - antarctica.cell_centers().points[:, 1]) ** 2
 ###############################################################################
 # Do weighted sampling.
 
-points = antarctica.ransam.surface_dataset(500, weights=weights)
+points = antarctica.ransame.surface_dataset(500, weights=weights)
 
 ###############################################################################
 # Now plot result.
@@ -49,7 +49,7 @@ pl.show()
 # The same thing can be done with cell data on the mesh.
 
 antarctica.cell_data["weights"] = weights
-points = antarctica.ransam.surface_dataset(500, weights="weights")
+points = antarctica.ransame.surface_dataset(500, weights="weights")
 
 ###############################################################################
 # Now plot result. The result will be slightly different due to random nature

--- a/examples_src/plot_03_volume_sampling.py
+++ b/examples_src/plot_03_volume_sampling.py
@@ -39,7 +39,7 @@ mesh["age"] = mesh.points[:, 1]
 # Sample the points with respect to the volume fraction to obtain a realistic
 # particle distribution in the domain.
 
-points = pyransame.random_volume_dataset(mesh, 1000, weights="volume_frac")
+points = mesh.ransam.volume_dataset(1000, weights="volume_frac")
 
 ###############################################################################
 # In this example, we also know the particles diameters come from a normal

--- a/examples_src/plot_03_volume_sampling.py
+++ b/examples_src/plot_03_volume_sampling.py
@@ -39,7 +39,7 @@ mesh["age"] = mesh.points[:, 1]
 # Sample the points with respect to the volume fraction to obtain a realistic
 # particle distribution in the domain.
 
-points = mesh.ransam.volume_dataset(1000, weights="volume_frac")
+points = mesh.ransame.volume_dataset(1000, weights="volume_frac")
 
 ###############################################################################
 # In this example, we also know the particles diameters come from a normal

--- a/examples_src/plot_05_random_points.py
+++ b/examples_src/plot_05_random_points.py
@@ -25,7 +25,7 @@ antarctica.points /= 1000.0  # convert to kilometers
 ###############################################################################
 # sample 500 points uniformly randomly.
 
-points = pyransame.random_surface_points(antarctica, 500)
+points = antarctica.ransam.surface_points(500)
 points
 
 ###############################################################################

--- a/examples_src/plot_05_random_points.py
+++ b/examples_src/plot_05_random_points.py
@@ -25,7 +25,7 @@ antarctica.points /= 1000.0  # convert to kilometers
 ###############################################################################
 # sample 500 points uniformly randomly.
 
-points = antarctica.ransam.surface_points(500)
+points = antarctica.ransame.surface_points(500)
 points
 
 ###############################################################################

--- a/examples_src/plot_06_random_number_generator.py
+++ b/examples_src/plot_06_random_number_generator.py
@@ -38,13 +38,13 @@ def plot_points(points):
 ###############################################################################
 # Sampling twice in succession will lead to different results.
 
-points = antarctica.ransam.surface_dataset(500)
+points = antarctica.ransame.surface_dataset(500)
 plot_points(points)
 
 ###############################################################################
 # Second sampling with slightly different results
 
-points = antarctica.ransam.surface_dataset(500)
+points = antarctica.ransame.surface_dataset(500)
 plot_points(points)
 
 ###############################################################################
@@ -52,12 +52,12 @@ plot_points(points)
 # ensure that the same result is obtained.
 
 pyransame.rng = np.random.default_rng(seed=42)
-points = antarctica.ransam.surface_dataset(500)
+points = antarctica.ransame.surface_dataset(500)
 plot_points(points)
 
 ###############################################################################
 # Second sampling with identical results.
 
 pyransame.rng = np.random.default_rng(seed=42)
-points = antarctica.ransam.surface_dataset(500)
+points = antarctica.ransame.surface_dataset(500)
 plot_points(points)

--- a/examples_src/plot_06_random_number_generator.py
+++ b/examples_src/plot_06_random_number_generator.py
@@ -38,13 +38,13 @@ def plot_points(points):
 ###############################################################################
 # Sampling twice in succession will lead to different results.
 
-points = pyransame.random_surface_dataset(antarctica, 500)
+points = antarctica.ransam.surface_dataset(500)
 plot_points(points)
 
 ###############################################################################
 # Second sampling with slightly different results
 
-points = pyransame.random_surface_dataset(antarctica, 500)
+points = antarctica.ransam.surface_dataset(500)
 plot_points(points)
 
 ###############################################################################
@@ -52,12 +52,12 @@ plot_points(points)
 # ensure that the same result is obtained.
 
 pyransame.rng = np.random.default_rng(seed=42)
-points = pyransame.random_surface_dataset(antarctica, 500)
+points = antarctica.ransam.surface_dataset(500)
 plot_points(points)
 
 ###############################################################################
 # Second sampling with identical results.
 
 pyransame.rng = np.random.default_rng(seed=42)
-points = pyransame.random_surface_dataset(antarctica, 500)
+points = antarctica.ransam.surface_dataset(500)
 plot_points(points)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,12 +28,12 @@ authors = [
 "Bug Tracker" = "https://github.com/MatthewFlamm/pyransame/issues"
 "Documentation" = "https://matthewflamm.github.io/pyransame/"
 
-# Register the ``ransam`` dataset accessor with PyVista (>= 0.48). On
+# Register the ``ransame`` dataset accessor with PyVista (>= 0.48). On
 # newer PyVista releases the accessor is loaded lazily on first attribute
 # access, so users only need ``pip install pyransame`` to get
-# ``mesh.ransam.*``. Older PyVista releases ignore this entry point.
+# ``mesh.ransame.*``. Older PyVista releases ignore this entry point.
 [project.entry-points."pyvista.accessors"]
-ransam = "pyransame.accessor"
+ransame = "pyransame.accessor"
 
 [tool.setuptools_scm]
 write_to = "src/pyransame/_version.py"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,6 +28,13 @@ authors = [
 "Bug Tracker" = "https://github.com/MatthewFlamm/pyransame/issues"
 "Documentation" = "https://matthewflamm.github.io/pyransame/"
 
+# Register the ``ransam`` dataset accessor with PyVista (>= 0.48). On
+# newer PyVista releases the accessor is loaded lazily on first attribute
+# access, so users only need ``pip install pyransame`` to get
+# ``mesh.ransam.*``. Older PyVista releases ignore this entry point.
+[project.entry-points."pyvista.accessors"]
+ransam = "pyransame.accessor"
+
 [tool.setuptools_scm]
 write_to = "src/pyransame/_version.py"
 

--- a/requirements-doc.txt
+++ b/requirements-doc.txt
@@ -2,7 +2,7 @@ jupyter_sphinx==0.5.3
 jupyterlab==4.5.7
 numpydoc==1.9.0
 pydata-sphinx-theme==0.16.1
-pyvista==0.45.2
+pyvista==0.48.0
 sphinx==8.2.1
 sphinx-design==0.6.1
 sphinx-gallery==0.19.0

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -2,4 +2,3 @@ pytest==8.4.2
 pytest-cov==7.1.0
 hypothesis==6.141.1
 mypy==1.18.2
-pyvista==0.45.2

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -2,3 +2,4 @@ pytest==8.4.2
 pytest-cov==7.1.0
 hypothesis==6.141.1
 mypy==1.18.2
+pyvista==0.45.2

--- a/src/pyransame/__init__.py
+++ b/src/pyransame/__init__.py
@@ -4,6 +4,10 @@ from numpy.random import default_rng
 
 rng = default_rng()
 
+# Register the ``ransam`` dataset accessor when the running PyVista
+# supports it (>= 0.48). Importing the module is a no-op otherwise so
+# the package stays importable on older PyVista releases.
+from .accessor import RansameAccessor  # noqa: E402
 from .line import random_line_dataset, random_line_points
 from .surface import random_surface_dataset, random_surface_points
 from .vertex import random_vertex_dataset, random_vertex_points

--- a/src/pyransame/__init__.py
+++ b/src/pyransame/__init__.py
@@ -4,7 +4,7 @@ from numpy.random import default_rng
 
 rng = default_rng()
 
-# Register the ``ransam`` dataset accessor when the running PyVista
+# Register the ``ransame`` dataset accessor when the running PyVista
 # supports it (>= 0.48). Importing the module is a no-op otherwise so
 # the package stays importable on older PyVista releases.
 from .accessor import RansameAccessor  # noqa: E402

--- a/src/pyransame/accessor.py
+++ b/src/pyransame/accessor.py
@@ -25,24 +25,6 @@ from pyransame.surface import random_surface_dataset, random_surface_points
 from pyransame.vertex import random_vertex_dataset, random_vertex_points
 from pyransame.volume import random_volume_dataset, random_volume_points
 
-# vtkCellTypes.GetDimension was deprecated in VTK 9.6 in favor of
-# vtkCellTypeUtilities.GetDimension. Try the new home first and fall
-# back to the legacy class on older VTK builds.
-try:
-    from vtkmodules.vtkCommonDataModel import (  # type: ignore[attr-defined]
-        vtkCellTypeUtilities,
-    )
-
-    def _cell_type_dimension(cell_type: int) -> int:
-        return vtkCellTypeUtilities.GetDimension(cell_type)
-
-except ImportError:  # pragma: no cover - exercised only on VTK < 9.6
-    from vtkmodules.vtkCommonDataModel import vtkCellTypes
-
-    def _cell_type_dimension(cell_type: int) -> int:
-        return vtkCellTypes.GetDimension(cell_type)
-
-
 ACCESSOR_NAME = "ransam"
 
 Kind = Literal["vertex", "line", "surface", "volume"]
@@ -180,23 +162,23 @@ class RansameAccessor:
 
     def _infer_kind(self) -> Kind:
         mesh = self._mesh
-        cell_types = mesh.distinct_cell_types
-        if not cell_types:
+        if mesh.n_cells == 0:
             msg = "Mesh has no cells; cannot infer sampling kind."
             raise ValueError(msg)
-        dims = {_cell_type_dimension(int(ct)) for ct in cell_types}
-        if len(dims) > 1:
+        lo = mesh.min_cell_dimensionality
+        hi = mesh.max_cell_dimensionality
+        if lo != hi:
+            dims = sorted({ct.dimension for ct in mesh.distinct_cell_types})
             kinds = sorted(_DIM_TO_KIND[d] for d in dims if d in _DIM_TO_KIND)
             msg = (
-                f"Mesh has cells of multiple dimensions ({sorted(dims)}, "
+                f"Mesh has cells of multiple dimensions ({dims}, "
                 f"kinds {kinds}); pass ``kind=`` to disambiguate."
             )
             raise ValueError(msg)
-        dim = dims.pop()
-        if dim not in _DIM_TO_KIND:
-            msg = f"Unsupported cell dimension {dim}; pass ``kind=`` explicitly."
+        if lo not in _DIM_TO_KIND:  # pragma: no cover - defensive guard
+            msg = f"Unsupported cell dimension {lo}; pass ``kind=`` explicitly."
             raise ValueError(msg)
-        return _DIM_TO_KIND[dim]
+        return _DIM_TO_KIND[lo]
 
     def points(
         self,
@@ -313,11 +295,11 @@ def _register() -> bool:
     re-import in tests).
     """
     register = getattr(pv, "register_dataset_accessor", None)
-    if register is None:
+    if register is None:  # pragma: no cover - exercised only on PyVista < 0.48
         return False
     try:
         register(ACCESSOR_NAME, pv.DataSet)(RansameAccessor)
-    except ValueError:
+    except ValueError:  # pragma: no cover - double-registration edge case
         # Already registered (e.g. plugin imported twice).
         return False
     return True

--- a/src/pyransame/accessor.py
+++ b/src/pyransame/accessor.py
@@ -1,16 +1,16 @@
 """PyVista dataset accessor for ``pyransame``.
 
-Registers a ``ransam`` accessor on :class:`pyvista.DataSet` so the
+Registers a ``ransame`` accessor on :class:`pyvista.DataSet` so the
 sampling routines can be invoked as methods on any PyVista mesh::
 
     >>> import pyvista as pv
     >>> import pyransame  # noqa: F401  (ensures accessor is registered)
     >>> mesh = pv.Plane()
-    >>> points = mesh.ransam.surface_points(10)
+    >>> points = mesh.ransame.surface_points(10)
 
 Importing this module is a no-op on PyVista versions that predate the
 dataset accessor API (added in PyVista 0.48). The package therefore
-remains importable on older PyVista releases; the ``ransam`` namespace
+remains importable on older PyVista releases; the ``ransame`` namespace
 will not be attached to datasets.
 """
 
@@ -25,7 +25,7 @@ from pyransame.surface import random_surface_dataset, random_surface_points
 from pyransame.vertex import random_vertex_dataset, random_vertex_points
 from pyransame.volume import random_volume_dataset, random_volume_points
 
-ACCESSOR_NAME = "ransam"
+ACCESSOR_NAME = "ransame"
 
 Kind = Literal["vertex", "line", "surface", "volume"]
 _DIM_TO_KIND: dict[int, Kind] = {
@@ -40,7 +40,7 @@ class RansameAccessor:
     """
     Accessor exposing :mod:`pyransame` sampling routines on a dataset.
 
-    Available as ``dataset.ransam`` once :mod:`pyransame` is imported on
+    Available as ``dataset.ransame`` once :mod:`pyransame` is imported on
     PyVista >= 0.48. Each method forwards to the corresponding
     top-level ``random_*`` function in :mod:`pyransame`.
     """
@@ -216,9 +216,9 @@ class RansameAccessor:
 
         Examples
         --------
-        >>> import pyransame  # noqa: F401  (registers ``ransam``)
+        >>> import pyransame  # noqa: F401  (registers ``ransame``)
         >>> import pyvista as pv
-        >>> pts = pv.Plane().ransam.points(5)
+        >>> pts = pv.Plane().ransame.points(5)
         >>> pts.shape
         (5, 3)
         """
@@ -261,9 +261,9 @@ class RansameAccessor:
 
         Examples
         --------
-        >>> import pyransame  # noqa: F401  (registers ``ransam``)
+        >>> import pyransame  # noqa: F401  (registers ``ransame``)
         >>> import pyvista as pv
-        >>> sampled = pv.Plane().ransam.dataset(5)
+        >>> sampled = pv.Plane().ransame.dataset(5)
         >>> sampled.n_points
         5
         """

--- a/src/pyransame/accessor.py
+++ b/src/pyransame/accessor.py
@@ -14,7 +14,7 @@ remains importable on older PyVista releases; the ``ransam`` namespace
 will not be attached to datasets.
 """
 
-from typing import Optional, Union
+from typing import Callable, Literal, Optional, Union
 
 import numpy as np
 import numpy.typing as npt
@@ -25,7 +25,33 @@ from pyransame.surface import random_surface_dataset, random_surface_points
 from pyransame.vertex import random_vertex_dataset, random_vertex_points
 from pyransame.volume import random_volume_dataset, random_volume_points
 
+# vtkCellTypes.GetDimension was deprecated in VTK 9.6 in favor of
+# vtkCellTypeUtilities.GetDimension. Try the new home first and fall
+# back to the legacy class on older VTK builds.
+try:
+    from vtkmodules.vtkCommonDataModel import (  # type: ignore[attr-defined]
+        vtkCellTypeUtilities,
+    )
+
+    def _cell_type_dimension(cell_type: int) -> int:
+        return vtkCellTypeUtilities.GetDimension(cell_type)
+
+except ImportError:  # pragma: no cover - exercised only on VTK < 9.6
+    from vtkmodules.vtkCommonDataModel import vtkCellTypes
+
+    def _cell_type_dimension(cell_type: int) -> int:
+        return vtkCellTypes.GetDimension(cell_type)
+
+
 ACCESSOR_NAME = "ransam"
+
+Kind = Literal["vertex", "line", "surface", "volume"]
+_DIM_TO_KIND: dict[int, Kind] = {
+    0: "vertex",
+    1: "line",
+    2: "surface",
+    3: "volume",
+}
 
 
 class RansameAccessor:
@@ -101,6 +127,121 @@ class RansameAccessor:
     ) -> pv.PolyData:
         """Random sampled :class:`pyvista.PolyData` from vertex cells. See :func:`pyransame.random_vertex_dataset`."""
         return random_vertex_dataset(self._mesh, n=n, weights=weights)
+
+    def _infer_kind(self) -> Kind:
+        mesh = self._mesh
+        cell_types = mesh.distinct_cell_types
+        if not cell_types:
+            msg = "Mesh has no cells; cannot infer sampling kind."
+            raise ValueError(msg)
+        dims = {_cell_type_dimension(int(ct)) for ct in cell_types}
+        if len(dims) > 1:
+            kinds = sorted(_DIM_TO_KIND[d] for d in dims if d in _DIM_TO_KIND)
+            msg = (
+                f"Mesh has cells of multiple dimensions ({sorted(dims)}, "
+                f"kinds {kinds}); pass ``kind=`` to disambiguate."
+            )
+            raise ValueError(msg)
+        dim = dims.pop()
+        if dim not in _DIM_TO_KIND:
+            msg = f"Unsupported cell dimension {dim}; pass ``kind=`` explicitly."
+            raise ValueError(msg)
+        return _DIM_TO_KIND[dim]
+
+    def points(
+        self,
+        n: int = 1,
+        weights: Optional[Union[str, npt.ArrayLike]] = None,
+        *,
+        kind: Optional[Kind] = None,
+    ) -> np.ndarray:
+        """Random points, dispatched by cell dimension.
+
+        Parameters
+        ----------
+        n : int, default: 1
+            Number of random points to generate.
+
+        weights : str or array_like, optional
+            Per-cell sampling weights, forwarded to the underlying
+            ``random_*_points`` routine.
+
+        kind : {"vertex", "line", "surface", "volume"}, optional
+            Force a specific sampler. When ``None`` (the default), the
+            kind is inferred from the cell dimensions present on the
+            mesh and a :class:`ValueError` is raised if more than one
+            dimension is found.
+
+        Returns
+        -------
+        numpy.ndarray
+            ``(n, 3)`` array of sampled points.
+
+        Examples
+        --------
+        >>> import pyransame  # noqa: F401  (registers ``ransam``)
+        >>> import pyvista as pv
+        >>> pts = pv.Plane().ransam.points(5)
+        >>> pts.shape
+        (5, 3)
+        """
+        resolved = kind if kind is not None else self._infer_kind()
+        return _POINTS_DISPATCH[resolved](self._mesh, n=n, weights=weights)
+
+    def dataset(
+        self,
+        n: int = 1,
+        weights: Optional[Union[str, npt.ArrayLike]] = None,
+        *,
+        kind: Optional[Kind] = None,
+    ) -> pv.PolyData:
+        """Random sampled :class:`pyvista.PolyData`, dispatched by cell dimension.
+
+        Parameters
+        ----------
+        n : int, default: 1
+            Number of random points to generate.
+
+        weights : str or array_like, optional
+            Per-cell sampling weights, forwarded to the underlying
+            ``random_*_dataset`` routine.
+
+        kind : {"vertex", "line", "surface", "volume"}, optional
+            Force a specific sampler. When ``None`` (the default), the
+            kind is inferred from the cell dimensions present on the
+            mesh and a :class:`ValueError` is raised if more than one
+            dimension is found.
+
+        Returns
+        -------
+        pyvista.PolyData
+            Sampled mesh with point data interpolated from the input.
+
+        Examples
+        --------
+        >>> import pyransame  # noqa: F401  (registers ``ransam``)
+        >>> import pyvista as pv
+        >>> sampled = pv.Plane().ransam.dataset(5)
+        >>> sampled.n_points
+        5
+        """
+        resolved = kind if kind is not None else self._infer_kind()
+        return _DATASET_DISPATCH[resolved](self._mesh, n=n, weights=weights)
+
+
+_POINTS_DISPATCH: dict[Kind, Callable[..., np.ndarray]] = {
+    "vertex": random_vertex_points,
+    "line": random_line_points,
+    "surface": random_surface_points,
+    "volume": random_volume_points,
+}
+
+_DATASET_DISPATCH: dict[Kind, Callable[..., pv.PolyData]] = {
+    "vertex": random_vertex_dataset,
+    "line": random_line_dataset,
+    "surface": random_surface_dataset,
+    "volume": random_volume_dataset,
+}
 
 
 def _register() -> bool:

--- a/src/pyransame/accessor.py
+++ b/src/pyransame/accessor.py
@@ -1,0 +1,125 @@
+"""PyVista dataset accessor for ``pyransame``.
+
+Registers a ``ransam`` accessor on :class:`pyvista.DataSet` so the
+sampling routines can be invoked as methods on any PyVista mesh::
+
+    >>> import pyvista as pv
+    >>> import pyransame  # noqa: F401  (ensures accessor is registered)
+    >>> mesh = pv.Plane()
+    >>> points = mesh.ransam.surface_points(10)
+
+Importing this module is a no-op on PyVista versions that predate the
+dataset accessor API (added in PyVista 0.48). The package therefore
+remains importable on older PyVista releases; the ``ransam`` namespace
+will not be attached to datasets.
+"""
+
+from typing import Optional, Union
+
+import numpy as np
+import numpy.typing as npt
+import pyvista as pv
+
+from pyransame.line import random_line_dataset, random_line_points
+from pyransame.surface import random_surface_dataset, random_surface_points
+from pyransame.vertex import random_vertex_dataset, random_vertex_points
+from pyransame.volume import random_volume_dataset, random_volume_points
+
+ACCESSOR_NAME = "ransam"
+
+
+class RansameAccessor:
+    """Accessor exposing :mod:`pyransame` sampling routines on a dataset.
+
+    Available as ``dataset.ransam`` once :mod:`pyransame` is imported on
+    PyVista >= 0.48.
+    """
+
+    def __init__(self, mesh: pv.DataSet) -> None:
+        self._mesh = mesh
+
+    def surface_points(
+        self,
+        n: int = 1,
+        weights: Optional[Union[str, npt.ArrayLike]] = None,
+    ) -> np.ndarray:
+        """Random points on 2D surface cells. See :func:`pyransame.random_surface_points`."""
+        return random_surface_points(self._mesh, n=n, weights=weights)
+
+    def surface_dataset(
+        self,
+        n: int = 1,
+        weights: Optional[Union[str, npt.ArrayLike]] = None,
+    ) -> pv.PolyData:
+        """Random sampled :class:`pyvista.PolyData` on surface cells. See :func:`pyransame.random_surface_dataset`."""
+        return random_surface_dataset(self._mesh, n=n, weights=weights)
+
+    def volume_points(
+        self,
+        n: int = 1,
+        weights: Optional[Union[str, npt.ArrayLike]] = None,
+    ) -> np.ndarray:
+        """Random points in 3D volume cells. See :func:`pyransame.random_volume_points`."""
+        return random_volume_points(self._mesh, n=n, weights=weights)
+
+    def volume_dataset(
+        self,
+        n: int = 1,
+        weights: Optional[Union[str, npt.ArrayLike]] = None,
+    ) -> pv.PolyData:
+        """Random sampled :class:`pyvista.PolyData` in volume cells. See :func:`pyransame.random_volume_dataset`."""
+        return random_volume_dataset(self._mesh, n=n, weights=weights)
+
+    def line_points(
+        self,
+        n: int = 1,
+        weights: Optional[Union[str, npt.ArrayLike]] = None,
+    ) -> np.ndarray:
+        """Random points on 1D line cells. See :func:`pyransame.random_line_points`."""
+        return random_line_points(self._mesh, n=n, weights=weights)
+
+    def line_dataset(
+        self,
+        n: int = 1,
+        weights: Optional[Union[str, npt.ArrayLike]] = None,
+    ) -> pv.PolyData:
+        """Random sampled :class:`pyvista.PolyData` on line cells. See :func:`pyransame.random_line_dataset`."""
+        return random_line_dataset(self._mesh, n=n, weights=weights)
+
+    def vertex_points(
+        self,
+        n: int = 1,
+        weights: Optional[Union[str, npt.ArrayLike]] = None,
+    ) -> np.ndarray:
+        """Random points sampled from 0D vertex cells. See :func:`pyransame.random_vertex_points`."""
+        return random_vertex_points(self._mesh, n=n, weights=weights)
+
+    def vertex_dataset(
+        self,
+        n: int = 1,
+        weights: Optional[Union[str, npt.ArrayLike]] = None,
+    ) -> pv.PolyData:
+        """Random sampled :class:`pyvista.PolyData` from vertex cells. See :func:`pyransame.random_vertex_dataset`."""
+        return random_vertex_dataset(self._mesh, n=n, weights=weights)
+
+
+def _register() -> bool:
+    """Attach the accessor to :class:`pyvista.DataSet`.
+
+    Returns ``True`` if registration succeeded, ``False`` if the running
+    PyVista does not support dataset accessors (<0.48) or if registration
+    raised because the accessor was already attached (e.g. during a
+    re-import in tests).
+    """
+    register = getattr(pv, "register_dataset_accessor", None)
+    if register is None:
+        return False
+    try:
+        register(ACCESSOR_NAME, pv.DataSet)(RansameAccessor)
+    except ValueError:
+        # Already registered (e.g. plugin imported twice).
+        return False
+    return True
+
+
+_register()

--- a/src/pyransame/accessor.py
+++ b/src/pyransame/accessor.py
@@ -55,10 +55,12 @@ _DIM_TO_KIND: dict[int, Kind] = {
 
 
 class RansameAccessor:
-    """Accessor exposing :mod:`pyransame` sampling routines on a dataset.
+    """
+    Accessor exposing :mod:`pyransame` sampling routines on a dataset.
 
     Available as ``dataset.ransam`` once :mod:`pyransame` is imported on
-    PyVista >= 0.48.
+    PyVista >= 0.48. Each method forwards to the corresponding
+    top-level ``random_*`` function in :mod:`pyransame`.
     """
 
     def __init__(self, mesh: pv.DataSet) -> None:
@@ -69,7 +71,13 @@ class RansameAccessor:
         n: int = 1,
         weights: Optional[Union[str, npt.ArrayLike]] = None,
     ) -> np.ndarray:
-        """Random points on 2D surface cells. See :func:`pyransame.random_surface_points`."""
+        """
+        Random points on 2D surface cells.
+
+        Forwards to :func:`pyransame.random_surface_points`. See that
+        function for the full parameter description and supported cell
+        types.
+        """
         return random_surface_points(self._mesh, n=n, weights=weights)
 
     def surface_dataset(
@@ -77,7 +85,13 @@ class RansameAccessor:
         n: int = 1,
         weights: Optional[Union[str, npt.ArrayLike]] = None,
     ) -> pv.PolyData:
-        """Random sampled :class:`pyvista.PolyData` on surface cells. See :func:`pyransame.random_surface_dataset`."""
+        """
+        Random sampled :class:`pyvista.PolyData` on surface cells.
+
+        Forwards to :func:`pyransame.random_surface_dataset`, which
+        returns a :class:`pyvista.PolyData` with point data interpolated
+        from the input mesh.
+        """
         return random_surface_dataset(self._mesh, n=n, weights=weights)
 
     def volume_points(
@@ -85,7 +99,13 @@ class RansameAccessor:
         n: int = 1,
         weights: Optional[Union[str, npt.ArrayLike]] = None,
     ) -> np.ndarray:
-        """Random points in 3D volume cells. See :func:`pyransame.random_volume_points`."""
+        """
+        Random points in 3D volume cells.
+
+        Forwards to :func:`pyransame.random_volume_points`. See that
+        function for the full parameter description and supported cell
+        types.
+        """
         return random_volume_points(self._mesh, n=n, weights=weights)
 
     def volume_dataset(
@@ -93,7 +113,13 @@ class RansameAccessor:
         n: int = 1,
         weights: Optional[Union[str, npt.ArrayLike]] = None,
     ) -> pv.PolyData:
-        """Random sampled :class:`pyvista.PolyData` in volume cells. See :func:`pyransame.random_volume_dataset`."""
+        """
+        Random sampled :class:`pyvista.PolyData` in volume cells.
+
+        Forwards to :func:`pyransame.random_volume_dataset`, which
+        returns a :class:`pyvista.PolyData` with point data interpolated
+        from the input mesh.
+        """
         return random_volume_dataset(self._mesh, n=n, weights=weights)
 
     def line_points(
@@ -101,7 +127,13 @@ class RansameAccessor:
         n: int = 1,
         weights: Optional[Union[str, npt.ArrayLike]] = None,
     ) -> np.ndarray:
-        """Random points on 1D line cells. See :func:`pyransame.random_line_points`."""
+        """
+        Random points on 1D line cells.
+
+        Forwards to :func:`pyransame.random_line_points`. See that
+        function for the full parameter description and supported cell
+        types.
+        """
         return random_line_points(self._mesh, n=n, weights=weights)
 
     def line_dataset(
@@ -109,7 +141,13 @@ class RansameAccessor:
         n: int = 1,
         weights: Optional[Union[str, npt.ArrayLike]] = None,
     ) -> pv.PolyData:
-        """Random sampled :class:`pyvista.PolyData` on line cells. See :func:`pyransame.random_line_dataset`."""
+        """
+        Random sampled :class:`pyvista.PolyData` on line cells.
+
+        Forwards to :func:`pyransame.random_line_dataset`, which returns
+        a :class:`pyvista.PolyData` with point data interpolated from
+        the input mesh.
+        """
         return random_line_dataset(self._mesh, n=n, weights=weights)
 
     def vertex_points(
@@ -117,7 +155,13 @@ class RansameAccessor:
         n: int = 1,
         weights: Optional[Union[str, npt.ArrayLike]] = None,
     ) -> np.ndarray:
-        """Random points sampled from 0D vertex cells. See :func:`pyransame.random_vertex_points`."""
+        """
+        Random points sampled from 0D vertex cells.
+
+        Forwards to :func:`pyransame.random_vertex_points`. See that
+        function for the full parameter description and supported cell
+        types.
+        """
         return random_vertex_points(self._mesh, n=n, weights=weights)
 
     def vertex_dataset(
@@ -125,7 +169,13 @@ class RansameAccessor:
         n: int = 1,
         weights: Optional[Union[str, npt.ArrayLike]] = None,
     ) -> pv.PolyData:
-        """Random sampled :class:`pyvista.PolyData` from vertex cells. See :func:`pyransame.random_vertex_dataset`."""
+        """
+        Random sampled :class:`pyvista.PolyData` from vertex cells.
+
+        Forwards to :func:`pyransame.random_vertex_dataset`, which
+        returns a :class:`pyvista.PolyData` with point data interpolated
+        from the input mesh.
+        """
         return random_vertex_dataset(self._mesh, n=n, weights=weights)
 
     def _infer_kind(self) -> Kind:
@@ -155,7 +205,12 @@ class RansameAccessor:
         *,
         kind: Optional[Kind] = None,
     ) -> np.ndarray:
-        """Random points, dispatched by cell dimension.
+        """
+        Random points, dispatched by cell dimension.
+
+        Inspects the mesh's distinct cell types and forwards to the
+        matching ``random_*_points`` function. Pass ``kind`` explicitly
+        to override the inferred dimension on mixed-dimension meshes.
 
         Parameters
         ----------
@@ -195,7 +250,12 @@ class RansameAccessor:
         *,
         kind: Optional[Kind] = None,
     ) -> pv.PolyData:
-        """Random sampled :class:`pyvista.PolyData`, dispatched by cell dimension.
+        """
+        Random sampled :class:`pyvista.PolyData`, dispatched by cell dimension.
+
+        Inspects the mesh's distinct cell types and forwards to the
+        matching ``random_*_dataset`` function. Pass ``kind`` explicitly
+        to override the inferred dimension on mixed-dimension meshes.
 
         Parameters
         ----------

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,3 @@
+import pyvista as pv
+
+pv.OFF_SCREEN = True

--- a/tests/test_accessor.py
+++ b/tests/test_accessor.py
@@ -76,6 +76,48 @@ def test_vertex_points_and_dataset():
     assert sampled.n_points == 10
 
 
+def test_dispatch_points_surface():
+    mesh = pv.Plane()
+    pts = mesh.ransam.points(20)
+    assert pts.shape == (20, 3)
+
+
+def test_dispatch_dataset_volume():
+    mesh = pv.ImageData(dimensions=(8, 8, 8))
+    sampled = mesh.ransam.dataset(15)
+    assert sampled.n_points == 15
+
+
+def test_dispatch_kind_override():
+    mesh = pv.Plane()
+    pts = mesh.ransam.points(10, kind="surface")
+    assert pts.shape == (10, 3)
+
+
+def test_dispatch_line_inferred():
+    mesh = pv.Line()
+    pts = mesh.ransam.points(7)
+    assert pts.shape == (7, 3)
+
+
+def test_dispatch_raises_on_mixed_dim():
+    # PolyData carrying both line and triangle cells.
+    plane = pv.Plane().triangulate()
+    line = pv.Line()
+    mixed = plane + line
+    with pytest.raises(ValueError, match="multiple dimensions"):
+        mixed.ransam.points(5)
+    # Override is honored.
+    pts = mixed.ransam.points(5, kind="surface")
+    assert pts.shape == (5, 3)
+
+
+def test_dispatch_raises_on_empty_mesh():
+    mesh = pv.PolyData()
+    with pytest.raises(ValueError, match="no cells"):
+        mesh.ransam.points(1)
+
+
 def test_accessor_available_on_subclasses():
     # Registering against ``DataSet`` should expose accessor on every
     # concrete subclass.

--- a/tests/test_accessor.py
+++ b/tests/test_accessor.py
@@ -1,4 +1,4 @@
-"""Tests for the ``ransam`` PyVista dataset accessor."""
+"""Tests for the ``ransame`` PyVista dataset accessor."""
 
 import numpy as np
 import pytest
@@ -7,7 +7,7 @@ import pyvista as pv
 import pyransame
 from pyransame import RansameAccessor
 
-ACCESSOR_NAME = "ransam"
+ACCESSOR_NAME = "ransame"
 
 pytestmark = pytest.mark.skipif(
     not hasattr(pv, "register_dataset_accessor"),
@@ -18,17 +18,17 @@ pytestmark = pytest.mark.skipif(
 def test_accessor_registered():
     mesh = pv.Plane()
     assert hasattr(mesh, ACCESSOR_NAME)
-    assert isinstance(mesh.ransam, RansameAccessor)
+    assert isinstance(mesh.ransame, RansameAccessor)
 
 
 def test_accessor_cached_per_instance():
     mesh = pv.Plane()
-    assert mesh.ransam is mesh.ransam
+    assert mesh.ransame is mesh.ransame
 
 
 def test_surface_points():
     mesh = pv.Plane()
-    points = mesh.ransam.surface_points(25)
+    points = mesh.ransame.surface_points(25)
     assert points.shape == (25, 3)
 
 
@@ -37,7 +37,7 @@ def test_surface_dataset_matches_function():
     mesh["x"] = mesh.points[:, 0]
 
     pyransame.rng = np.random.default_rng(0)
-    sampled_method = mesh.ransam.surface_dataset(50)
+    sampled_method = mesh.ransame.surface_dataset(50)
 
     pyransame.rng = np.random.default_rng(0)
     sampled_func = pyransame.random_surface_dataset(mesh, 50)
@@ -48,19 +48,19 @@ def test_surface_dataset_matches_function():
 
 def test_volume_points_and_dataset():
     mesh = pv.ImageData(dimensions=(10, 10, 10))
-    points = mesh.ransam.volume_points(20)
+    points = mesh.ransame.volume_points(20)
     assert points.shape == (20, 3)
 
-    sampled = mesh.ransam.volume_dataset(20)
+    sampled = mesh.ransame.volume_dataset(20)
     assert sampled.n_points == 20
 
 
 def test_line_points_and_dataset():
     mesh = pv.Line()
-    points = mesh.ransam.line_points(15)
+    points = mesh.ransame.line_points(15)
     assert points.shape == (15, 3)
 
-    sampled = mesh.ransam.line_dataset(15)
+    sampled = mesh.ransame.line_dataset(15)
     assert sampled.n_points == 15
 
 
@@ -69,34 +69,34 @@ def test_line_points_and_dataset():
 )
 def test_vertex_points_and_dataset():
     mesh = pv.PolyData(pv.ImageData(dimensions=(5, 5, 5)).points)
-    points = mesh.ransam.vertex_points(10)
+    points = mesh.ransame.vertex_points(10)
     assert points.shape == (10, 3)
 
-    sampled = mesh.ransam.vertex_dataset(10)
+    sampled = mesh.ransame.vertex_dataset(10)
     assert sampled.n_points == 10
 
 
 def test_dispatch_points_surface():
     mesh = pv.Plane()
-    pts = mesh.ransam.points(20)
+    pts = mesh.ransame.points(20)
     assert pts.shape == (20, 3)
 
 
 def test_dispatch_dataset_volume():
     mesh = pv.ImageData(dimensions=(8, 8, 8))
-    sampled = mesh.ransam.dataset(15)
+    sampled = mesh.ransame.dataset(15)
     assert sampled.n_points == 15
 
 
 def test_dispatch_kind_override():
     mesh = pv.Plane()
-    pts = mesh.ransam.points(10, kind="surface")
+    pts = mesh.ransame.points(10, kind="surface")
     assert pts.shape == (10, 3)
 
 
 def test_dispatch_line_inferred():
     mesh = pv.Line()
-    pts = mesh.ransam.points(7)
+    pts = mesh.ransame.points(7)
     assert pts.shape == (7, 3)
 
 
@@ -106,16 +106,16 @@ def test_dispatch_raises_on_mixed_dim():
     line = pv.Line()
     mixed = plane + line
     with pytest.raises(ValueError, match="multiple dimensions"):
-        mixed.ransam.points(5)
+        mixed.ransame.points(5)
     # Override is honored.
-    pts = mixed.ransam.points(5, kind="surface")
+    pts = mixed.ransame.points(5, kind="surface")
     assert pts.shape == (5, 3)
 
 
 def test_dispatch_raises_on_empty_mesh():
     mesh = pv.PolyData()
     with pytest.raises(ValueError, match="no cells"):
-        mesh.ransam.points(1)
+        mesh.ransame.points(1)
 
 
 def test_accessor_available_on_subclasses():
@@ -126,4 +126,4 @@ def test_accessor_available_on_subclasses():
         pv.ImageData(dimensions=(4, 4, 4)),
         pv.Line(),
     ):
-        assert isinstance(mesh.ransam, RansameAccessor)
+        assert isinstance(mesh.ransame, RansameAccessor)

--- a/tests/test_accessor.py
+++ b/tests/test_accessor.py
@@ -1,0 +1,87 @@
+"""Tests for the ``ransam`` PyVista dataset accessor."""
+
+import numpy as np
+import pytest
+import pyvista as pv
+
+import pyransame
+from pyransame import RansameAccessor
+
+ACCESSOR_NAME = "ransam"
+
+pytestmark = pytest.mark.skipif(
+    not hasattr(pv, "register_dataset_accessor"),
+    reason="requires PyVista >= 0.48 dataset accessor API",
+)
+
+
+def test_accessor_registered():
+    mesh = pv.Plane()
+    assert hasattr(mesh, ACCESSOR_NAME)
+    assert isinstance(mesh.ransam, RansameAccessor)
+
+
+def test_accessor_cached_per_instance():
+    mesh = pv.Plane()
+    assert mesh.ransam is mesh.ransam
+
+
+def test_surface_points():
+    mesh = pv.Plane()
+    points = mesh.ransam.surface_points(25)
+    assert points.shape == (25, 3)
+
+
+def test_surface_dataset_matches_function():
+    mesh = pv.Plane()
+    mesh["x"] = mesh.points[:, 0]
+
+    pyransame.rng = np.random.default_rng(0)
+    sampled_method = mesh.ransam.surface_dataset(50)
+
+    pyransame.rng = np.random.default_rng(0)
+    sampled_func = pyransame.random_surface_dataset(mesh, 50)
+
+    assert np.allclose(sampled_method.points, sampled_func.points)
+    assert np.allclose(sampled_method["x"], sampled_func["x"])
+
+
+def test_volume_points_and_dataset():
+    mesh = pv.ImageData(dimensions=(10, 10, 10))
+    points = mesh.ransam.volume_points(20)
+    assert points.shape == (20, 3)
+
+    sampled = mesh.ransam.volume_dataset(20)
+    assert sampled.n_points == 20
+
+
+def test_line_points_and_dataset():
+    mesh = pv.Line()
+    points = mesh.ransam.line_points(15)
+    assert points.shape == (15, 3)
+
+    sampled = mesh.ransam.line_dataset(15)
+    assert sampled.n_points == 15
+
+
+@pytest.mark.skipif(
+    pv.vtk_version_info < (9, 3), reason="requires vtk version 9.3 or higher"
+)
+def test_vertex_points_and_dataset():
+    mesh = pv.PolyData(pv.ImageData(dimensions=(5, 5, 5)).points)
+    points = mesh.ransam.vertex_points(10)
+    assert points.shape == (10, 3)
+
+    sampled = mesh.ransam.vertex_dataset(10)
+    assert sampled.n_points == 10
+
+
+def test_accessor_available_on_subclasses():
+    # Registering against ``DataSet`` should expose accessor on every
+    # concrete subclass.
+    for mesh in (
+        pv.Plane(),
+        pv.ImageData(dimensions=(4, 4, 4)),
+        pv.Line(),
+    ):
+        assert isinstance(mesh.ransam, RansameAccessor)


### PR DESCRIPTION
Uses PyVista v0.48's new dataset accessor to expose pyransame directly from PyVista dataset instances

See https://docs.pyvista.org/extras/extending_pyvista

```py
import pyvista as pv
from pyvista import examples

bunny = examples.download_bunny()
points = bunny.ransam.surface_points(500)        # numpy array, shape (500, 3)
sampled = bunny.ransam.surface_dataset(500)      # pyvista.PolyData with interpolated arrays
```